### PR TITLE
Algo v2

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -588,13 +588,13 @@ func (app *TerraApp) Name() string { return app.BaseApp.Name() }
 // BeginBlocker application updates every begin block
 func (app *TerraApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 
-	if ctx.ChainID() == core.ColumbusChainID && ctx.BlockHeight() == core.SwapDisableForkHeight {
-		// Make min spread to one to disable swap
+	if ctx.ChainID() == core.ColumbusChainID && ctx.BlockHeight() == core.SwapEnableForkHeight {
+		// Make min spread to 75% to enable swap
 		params := app.MarketKeeper.GetParams(ctx)
-		params.MinStabilitySpread = sdk.OneDec()
+		params.MinStabilitySpread = sdk.NewDecWithPrec(75, 2)
 		app.MarketKeeper.SetParams(ctx, params)
 
-		// Disable IBC Channels
+		// Enable IBC Channels
 		channelIDs := []string{
 			"channel-1",  // Osmosis
 			"channel-49", // Crescent
@@ -606,7 +606,7 @@ func (app *TerraApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) a
 				panic(fmt.Sprintf("%s not found", channelID))
 			}
 
-			channel.State = ibcchanneltypes.CLOSED
+			channel.State = ibcchanneltypes.OPEN
 			app.IBCKeeper.ChannelKeeper.SetChannel(ctx, ibctransfertypes.PortID, channelID, channel)
 		}
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -589,9 +589,9 @@ func (app *TerraApp) Name() string { return app.BaseApp.Name() }
 func (app *TerraApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) abci.ResponseBeginBlock {
 
 	if ctx.ChainID() == core.ColumbusChainID && ctx.BlockHeight() == core.SwapEnableForkHeight {
-		// Make min spread to 75% to enable swap
+		// Make min spread to 98% to enable swap
 		params := app.MarketKeeper.GetParams(ctx)
-		params.MinStabilitySpread = sdk.NewDecWithPrec(75, 2)
+		params.MinStabilitySpread = sdk.NewDecWithPrec(98, 2)
 		app.MarketKeeper.SetParams(ctx, params)
 
 		// Enable IBC Channels

--- a/types/alias.go
+++ b/types/alias.go
@@ -39,6 +39,7 @@ const (
 	ColumbusChainID       = "columbus-5"
 	BombayChainID         = "bombay-12"
 	SwapDisableForkHeight = fork.SwapDisableForkHeight
+	SwapEnableForkHeight  = fork.SwapEnableForkHeight
 )
 
 // functions aliases

--- a/types/fork/height.go
+++ b/types/fork/height.go
@@ -3,5 +3,5 @@ package fork
 // SwapDisableForkHeight - make min spread to 100% to disable swap
 const SwapDisableForkHeight = 7607790
 
-// SwapEnableForkHeight - make min spread to 50% to enable swap with new guards
+// SwapEnableForkHeight - make min spread to 98% to enable swap with new guards
 const SwapEnableForkHeight = 9000000

--- a/types/fork/height.go
+++ b/types/fork/height.go
@@ -2,3 +2,6 @@ package fork
 
 // SwapDisableForkHeight - make min spread to 100% to disable swap
 const SwapDisableForkHeight = 7607790
+
+// SwapEnableForkHeight - make min spread to 50% to enable swap with new guards
+const SwapEnableForkHeight = 9000000

--- a/x/market/keeper/msg_server.go
+++ b/x/market/keeper/msg_server.go
@@ -101,8 +101,8 @@ func (k msgServer) handleSwapRequest(ctx sdk.Context,
 	// Mint asked coins and credit Trader's account
 	swapCoin, decimalCoin := swapDecCoin.TruncateDecimal()
 
-	// Ensure to fail the swap tx when zero swap coin
-	if ctx.ChainID() == core.ColumbusChainID && ctx.BlockHeight() >= core.SwapDisableForkHeight {
+	// Ensure to fail the swap tx when zero swap coin if tx happens between 1st and 2nd fork
+	if ctx.ChainID() == core.ColumbusChainID && ctx.BlockHeight() >= core.SwapDisableForkHeight && ctx.BlockHeight() < core.SwapEnableForkHeight {
 		if !swapCoin.IsPositive() {
 			return nil, types.ErrZeroSwapCoin
 		}

--- a/x/market/types/errors.go
+++ b/x/market/types/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrRecursiveSwap    = sdkerrors.Register(ModuleName, 2, "recursive swap")
 	ErrNoEffectivePrice = sdkerrors.Register(ModuleName, 3, "no price registered with oracle")
 	ErrZeroSwapCoin     = sdkerrors.Register(ModuleName, 4, "zero swap coin")
+	ErrExceedMaxDelta   = sdkerrors.Register(ModuleName, 5, "exceeded maximum ask coin delta")
 )


### PR DESCRIPTION
## Summary of changes

Re-enable limited swapping at blockHeight 9000000 with MinStab spread in marketkeeper changed from 100% -> 98% and reopen IBC channels. Furthermore a hard-coded cap on the amount of LUNC tokens that the ComputeSwap method will allow to exist has been set at 2T. If MaxDelta is exceeded when trading from Terra -> LUNC a new cosmos sdk error has been introduced which will be returned by the ComputeSwap method to inform the person wishing to perform the swap that they cannot do so. 
